### PR TITLE
More magic: regular expressions, parametric tests

### DIFF
--- a/codenames/codemaster.py
+++ b/codenames/codemaster.py
@@ -1,3 +1,6 @@
+import re
+
+
 def prompt_for_codemaster(board_cards, team):
     opponent = {'red': 'blue', 'blue': 'red'}
     prompt = f"""You are playing Codenames, you are the Codemaster.
@@ -16,7 +19,7 @@ Your response (clue word and number separated by comma):"""
 
 
 def parse_codemaster_response(response_text):
-    response_text = response_text.replace(',', ' ')
-    s1, s2 = map(str, response_text.split())
-    s1 = s1.replace(',', '')
+    match = re.match(r'\s*(\b[\w-]+\b)[,;\s]+(\b\d+\b)', response_text)
+    s1, s2 = match.groups()
+    s2 = int(s2)
     return s1, int(s2)

--- a/tests/test_prompt_parsing.py
+++ b/tests/test_prompt_parsing.py
@@ -1,7 +1,22 @@
 import pytest
 from codenames import parse_codemaster_response
 
+
 def test_parse_response_simple():
     clue_word, number = parse_codemaster_response('kiskutya, 3')
-    assert clue_word.lower()=='kiskutya'
-    assert number==3
+    assert clue_word.lower() == 'kiskutya'
+    assert number == 3
+
+
+@pytest.mark.parametrize("input,expected_clue_word,expected_number", [
+    ('fasirt, 343', 'fasirt', 343),
+    ('bow-tie, 54', 'bow-tie', 54),
+    ('word 42 garbage foobar\nmore stuff', 'word', 42),
+    ('word\n23', 'word', 23),
+    ('word, 0', 'word', 0),
+    (' krumpli, 4', 'krumpli', 4)
+])
+def test_parse_response_parametrized(input, expected_clue_word, expected_number):
+    clue_word, number = parse_codemaster_response(input)
+    assert expected_clue_word.lower() == clue_word.lower()
+    assert expected_number == number


### PR DESCRIPTION
## Today's new magic

### Regular expressions to parse response

I changed the `parse_codemaster_response` function to use regular expressions. Regular expressions are a very widely used, but also very ugly-looking, tool, with a bit of interesting theory behind them. You can use them to find various patterns within text. In this particular case I use the following regular expression matching:

```
re.match(r'\s*(\b[\w-]+\b)[,;\s]+(\b\d+\b)', response_text)
```

This uses the `re` python module for regular expressions, to match the regular expression `r'\s*(\b[\w-]+\b)[,;\s]+(\b\d+\b)'` against the string `response_text`. Let's look at what this regular expression describes:
* `\s` means white space. This matches any space, tab, newline or similar white space character.
*  `*` is a modifier that applies to what was written before, and means I match 0 or more repetitions of the thing that came before. So `\s*` matches 0 or more white space characters. The meaning of this here is to say the response may begin with spaces or newlines, and we will just ignore them.
* `()` parantheses are used to denote capture groups. The thing inside the capture group is the part of text we are actually intersted in
* `\b` means word boundary. It's not an actual character, it's the boundary between white space and something else
* `[]` square brackets denote options. It's going to match either of the patterns inside it. For example `[ab]` matches the character `a` or the character `b`, but nothing else.
* `\w` denotes word characters, i.e. upper and lowercase letters
*  `-` simply means the dash (`-`) character, which appears in the word "bow-tie". So, taken together [\w-] matches any letter or a dash.
* '+' means one or more. It's similar to `*` except `*` can be 0, `+` requires at least one occurrence.
* taken together `(\b[\w-]+\b)` will match a word that is made up of at least 1 or more characters including the dash, and the parantheses will capture this word, and this will be the first output of the regex matching.
* `[,;\s]+` matches one or more white space or `,` or `;` characters, which we expect to be there between the clue word and the number. This works even if there's a newline or many spaces, or whatever.
* `\d` matches digits, i.e. `0`, `1`, ..., `9`. The second capture group `(\b\d+\b)` therefore captures a string made up of one or more digits, i.e. an integer.

If the matching is successful, i.e. the string matched the pattern, the `re.match` function returns a `Match` object, which has a function called `groups()`. This returns the substrings that matched the capture groups in our regex. Since our first capture group captured the word, and the second capture group captured the number, this will return the two substrings corresponding to these two pieces of information.

Regular expressions are used a lot in practice, but they also have very interesting theory. They are connected to regular languages, and finite state automata, fundamental concepts in the theory of computation. This is part of Year 13 curriculum in the UK. Here are some [lecture notes](https://pmt.physicsandmathstutor.com/download/Computer-Science/A-level/Notes/AQA/04-Theory-of-Computation/Advanced/4.2.%20Regular%20Languages.pdf) and [a video](https://www.physicsandmathstutor.com/computer-science-revision/a-level-aqa/theory-of-computation/regular-languages-videos/) on this.

What's the advantage of doing it this way? Regular expressions are very flexible and they can capture more possible patterns in the returned response. The previous implementation assumed that there will be a comma, that the string only contains two substrings, etc. This regular expression can match a much broader range of returned texts successfully. Plus, it gave me an opportunity to teach you even more confusing stuff in a short amount of time.

### Parametrized tests

Sometimes you want to test the function's behaviour for a lot of different inputs. You don't want to write a new test for each of these inputs. Instead, you want to write one test, and then parametrize it, i.e. call it with different inputs and expected outputs. Here's how you can do this with pytest:

```
@pytest.mark.parametrize("input,expected_clue_word,expected_number", [
    ('fasirt, 343', 'fasirt', 343),
    ('bow-tie, 54', 'bow-tie', 54),
    ('word 42 garbage foobar\nmore stuff', 'word', 42),
    ('word\n23', 'word', 23),
    ('word, 0', 'word', 0),
    (' krumpli, 4', 'krumpli', 4),
    ('Argentina, 3', 'Argentina', 3)
])
def test_parse_response_parametrized(input, expected_clue_word, expected_number):
    clue_word, number = parse_codemaster_response(input)
    assert expected_clue_word.lower() == clue_word.lower()
    assert expected_number == number
```

The `@` part is called a decorator in python. You add these before definition of functions, and they modify the function's behaviour. You don't have to understand how this works, parametric tests are the only time you will use them for now.

This decorator, `pytest.mark.parametrize` allows you to call the test with different inputs. You will see a list of tuples, each of which is an input string, the expected clue word extracted from this string, and the number you expect to be extracted. For example, when the input is ` krumpli, 4`, you want the function to extract `krumpli` and `4`, hence the line `(;; krumpli, 4)`, 'krumpli', '4'.